### PR TITLE
Add ROM PID to udev rules; sync rules between all copies.

### DIFF
--- a/install/10-tessel.rules
+++ b/install/10-tessel.rules
@@ -1,1 +1,3 @@
+ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0002", MODE="0666"
 ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="2002", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"
+ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6097", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"

--- a/install/linux.sh
+++ b/install/linux.sh
@@ -57,6 +57,7 @@ touch `npm -g prefix`/lib/node_modules && npm install -g || sudo npm install -g
 # Install rules on Linux
 if [ "$(uname)" != "Darwin" ]; then
   sudo tee /etc/udev/rules.d/10-tessel.rules > /dev/null << EOF
+ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0002", MODE="0666"
 ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="2002", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"
 ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6097", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"
 EOF

--- a/install/osx.sh
+++ b/install/osx.sh
@@ -56,6 +56,10 @@ touch `npm -g prefix`/lib/node_modules && npm install -g || sudo npm install -g
 
 # Install rules on Linux
 if [ "$(uname)" != "Darwin" ]; then
-  echo 'ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="2002", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"' | sudo tee -a /etc/udev/rules.d/10-tessel.rules
-  sudo udevadm control --reload-rules
+    sudo tee /etc/udev/rules.d/10-tessel.rules > /dev/null << EOF
+ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0002", MODE="0666"
+ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="2002", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"
+ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6097", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"
+EOF
+    sudo udevadm control --reload-rules
 fi


### PR DESCRIPTION
Why are udev rules in `osx.sh` anyway?
