### PR TITLE
Fix `tessel firmware` bootloader auto-entry on Windows by hacking around libusb bug.

### DIFF
--- a/dfu/tessel-dfu.js
+++ b/dfu/tessel-dfu.js
@@ -119,10 +119,11 @@ function waitForBootloader(callback) {
 
     var retrycount = 5;
     setTimeout(function retry (error) {
-        device = findDevice();
+        var device = findDevice();
         state = guessDeviceState(device);
         if (state !== 'dfu') {
             if (--retrycount > 0) {
+                device.__destroy(); // Workaround for https://github.com/libusb/libusb/issues/7
                 return setTimeout(retry, 1000)
             } else {
                 console.error("Failed to load bootloader: found state", state);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",
     "temp": "~0.6.0",
-    "usb": "~0.3.9",
+    "usb": "~0.3.11",
     "colorsafeconsole": "0.0.4",
     "xml2js": "~0.4.1",
     "structured-clone": "~0.2.2",


### PR DESCRIPTION
Could be conditional to Windows only, but it should do no harm elsewhere, and it'll get more testing this way.

<!--travisplexer-->

---

<table><tr><td><b>Linux</b></td><td>
<a href="https://magnum.travis-ci.com/tessel/cli"><img alt="Build Status" src="https://magnum.travis-ci.com/tessel/cli.svg?token=QsFQ9CsYegvj7x78qiit&branch=travis-pr-33-linux"></a>
</td></tr></table>
