### PR TITLE
Uses the public npm repo colony-compiler instead.

### DIFF
--- a/bin/tessel-node.js
+++ b/bin/tessel-node.js
@@ -5,7 +5,7 @@ var path = require('path')
 var common = require('../src/cli')
 var keypress = require('keypress')
 var read = require('read')
-var colony = require('colony')
+var colonyCompiler = require('colony-compiler')
 
 // Setup cli.
 common.basic();
@@ -88,7 +88,7 @@ function repl (client)
         }
         var script
           // = 'function _locals()\nlocal variables = {}\nlocal idx = 1\nwhile true do\nlocal ln, lv = debug.getlocal(2, idx)\nif ln ~= nil then\n_G[ln] = lv\nelse\nbreak\nend\nidx = 1 + idx\nend\nreturn variables\nend\n'
-          = 'local function _run ()\n' + colony.colonize(data, {returnLastStatement: true, wrap: false}) + '\nend\nsetfenv(_run, colony.global);\nreturn _run()';
+          = 'local function _run ()\n' + colonyCompiler.colonize(data, {returnLastStatement: true, wrap: false}) + '\nend\nsetfenv(_run, colony.global);\nreturn _run()';
         client.command('M', new Buffer(JSON.stringify(script)));
       } catch (e) {
         console.error(e.stack);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "choices": "0.0.2",
     "colors": "~0.6.0-1",
-    "colony": "git+https://tmTestUser:tmTestUser1@github.com/tessel/colony.git",
+    "colony-compiler": "~0.5.0-1",
     "my-local-ip": "~1.0.0",
     "portscanner": "~0.1.3",
     "optimist": "~0.6.0",

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -2,7 +2,7 @@ var net = require('net');
 var fs = require('fs');
 var path = require('path')
   , temp = require('temp')
-  , colony = require('colony')
+  , colonyCompiler = require('colony-compiler')
   , async = require('async')
   , fstream = require('fstream')
   , tar = require('tar')
@@ -51,7 +51,7 @@ exports.bundleFiles = function (startpath, args, files, next)
       var f = _f[0], fullpath = _f[1];
 
       try {
-        var res = colony.colonize(fs.readFileSync(fullpath, 'utf-8'));
+        var res = colonyCompiler.colonize(fs.readFileSync(fullpath, 'utf-8'));
       } catch (e) {
         e.filename = f.substr(4);
         console.log('Syntax error in', f, ':\n', e);
@@ -63,7 +63,7 @@ exports.bundleFiles = function (startpath, args, files, next)
         next(null);
       } else {
         try {
-          colony.toBytecode(res, '/' + f.split(path.sep).join('/'), function (err, bytecode) {
+          colonyCompiler.toBytecode(res, '/' + f.split(path.sep).join('/'), function (err, bytecode) {
             !err && fs.writeFileSync(fullpath, bytecode);
             next(err);
           });


### PR DESCRIPTION
This is needed as a separate dependency for `tessel-cli`.

<!--travisplexer-->

---

<table><tr><td><b>Linux</b></td><td>
<a href="https://magnum.travis-ci.com/tessel/cli"><img alt="Build Status" src="https://magnum.travis-ci.com/tessel/cli.svg?token=QsFQ9CsYegvj7x78qiit&branch=travis-pr-36-linux"></a>
</td></tr></table>
