### PR TITLE
Stop code execution before enabling logging

### DIFF
--- a/bin/tessel-blink.js
+++ b/bin/tessel-blink.js
@@ -10,7 +10,7 @@ var common = require('../src/cli')
 // Setup cli.
 common.basic();
 
-common.controller(function (err, client) {
+common.controller(true, function (err, client) {
   client.listen(true, [10, 11, 12, 13, 20, 21, 22])
   client.on('error', function (err) {
     if (err.code == 'ENOENT') {

--- a/bin/tessel-debug-stack.js
+++ b/bin/tessel-debug-stack.js
@@ -5,7 +5,7 @@ var common = require('../src/cli')
 // Setup cli.
 common.basic();
 
-common.controller(function (err, client) {
+common.controller(false, function (err, client) {
   console.log('Requesting stack trace from Tessel...'.grey);
 
   client.debugstack(function(err, stack) {

--- a/bin/tessel-debug.js
+++ b/bin/tessel-debug.js
@@ -169,7 +169,7 @@ function userScript(id, client, urls){
   });
 }
 
-common.controller(function (err, client) {
+common.controller(true, function (err, client) {
   client.listen(true);
   client.wifiVer(function(err, wifiVer){
     initDebug(client.serialNumber, wifiVer, client.version, function(init){

--- a/bin/tessel-erase.js
+++ b/bin/tessel-erase.js
@@ -5,7 +5,7 @@ var common = require('../src/cli')
 // Setup cli.
 common.basic();
 
-common.controller(function (err, client) {
+common.controller(true, function (err, client) {
   client.erase(function () {
     console.log('Tessel filesystem erased.');
       client.close();

--- a/bin/tessel-logs.js
+++ b/bin/tessel-logs.js
@@ -5,6 +5,6 @@ var common = require('../src/cli')
 // Setup cli.
 common.basic();
 
-common.controller(function (err, client) {
+common.controller(false, function (err, client) {
   client.listen(true, [10, 11, 12, 13, 20, 21, 22])
 })

--- a/bin/tessel-node.js
+++ b/bin/tessel-node.js
@@ -98,7 +98,7 @@ function repl (client)
   }
 }
 
-common.controller(function (err, client) {
+common.controller(true, function (err, client) {
   client.listen(true, [10, 11, 12, 13, 20, 21, 22])
   client.on('error', function (err) {
     if (err.code == 'ENOENT') {

--- a/bin/tessel-push.js
+++ b/bin/tessel-push.js
@@ -49,7 +49,7 @@ function usage () {
   process.exit(1);
 }
 
-common.controller(function (err, client) {
+common.controller(true, function (err, client) {
   client.listen(true, [10, 11, 12, 13, 20, 21, 22])
   client.on('error', function (err) {
     if (err.code == 'ENOENT') {

--- a/bin/tessel-stop.js
+++ b/bin/tessel-stop.js
@@ -5,9 +5,7 @@ var common = require('../src/cli')
 // Setup cli.
 common.basic();
 
-common.controller(function (err, client) {
-  client.stop(function () {
+common.controller(true, function (err, client) {
     console.log('tessel runtime stopped.');
-      client.close();
-    });
+    client.close();
 })

--- a/bin/tessel-verbose.js
+++ b/bin/tessel-verbose.js
@@ -5,6 +5,6 @@ var common = require('../src/cli')
 // Setup cli.
 common.basic();
 
-common.controller(function (err, client) {
+common.controller(false, function (err, client) {
   client.listen(true);
 })

--- a/bin/tessel-wifi.js
+++ b/bin/tessel-wifi.js
@@ -7,7 +7,7 @@ common.basic();
 
 var argv = require('optimist').argv;
 
-common.controller(function (err, client) {
+common.controller(false, function (err, client) {
   client.listen(true, null); // TODO: should use [20, 21, 22, 86] once firmware logs at the right level
   if (argv._.length == 1) {
     client.wifiStatus(function (err, data) {

--- a/dfu/tessel-dfu.js
+++ b/dfu/tessel-dfu.js
@@ -148,7 +148,7 @@ exports.enterStage2 = function(callback) {
         var t = new Tessel(device);
         t.rx = false;
         t.init(function() {
-            t.claim(function(e) {
+            t.claim(true, function(e) {
                 if (e) throw e;
                 t.enterBootloader();
                 waitForBootloader(callback);

--- a/src/cli.js
+++ b/src/cli.js
@@ -39,10 +39,16 @@ var header = {
   }
 }
 
-function controller (next)
+function controller (stop, next)
 {
   header.init();
-  tessel.findTessel(null, function (err, client) {
+
+  if (typeof stop === 'function' && typeof next === 'undefined') {
+    next = stop;
+    stop = false;
+  }
+
+  tessel.findTessel(null, stop, function (err, client) {
     if (!client || err) {
       console.error('ERR'.red, err);
       return;

--- a/src/tessel_usb.js
+++ b/src/tessel_usb.js
@@ -43,11 +43,15 @@ Tessel.prototype.init = function init(next) {
 	})
 }
 
-Tessel.prototype.claim = function claim(next) {
+Tessel.prototype.claim = function claim(stop, next) {
 	// Runs the claiming procedure exactly once, and calls next after it has completed
 	if (this.claimed === 'claimed') {
 		// Already claimed
-		return setImmediate(next);
+		if (stop) {
+			this.stop(next);
+		} else {
+			return setImmediate(next);
+		}
 	}
 
 	this.once('claimed', next);
@@ -57,6 +61,11 @@ Tessel.prototype.claim = function claim(next) {
 		var self = this;
 		self.intf = self.usb.interface(0);
 		self.intf.claim();
+
+		if (stop) {
+			this.stop();
+		}
+
 		// We use an alternate setting so it is automatically released if the program is killed
 		self.intf.setAltSetting(1, function(error) {
 			if (error) return next(error);
@@ -230,13 +239,18 @@ Tessel.prototype.wifiVer = function (next) {
 	});
 }
 
-exports.findTessel = function findTessel(desiredSerial, next) {
+exports.findTessel = function findTessel(desiredSerial, stop, next) {
+	if (typeof stop === 'function' && typeof next === 'undefined') {
+		next = stop;
+		stop = false;
+	}
+
 	exports.listDevices(function (err, devices) {
 		if (err) return next(err);
 
 		for (var i=0; i<devices.length; i++) {
 			if (!desiredSerial || desiredSerial == devices[i].serialNumber) {
-				devices[i].claim(function(err) {
+				devices[i].claim(stop, function(err) {
 					if (err) return next(err);
 					return next(null, devices[i]);
 				});


### PR DESCRIPTION
Otherwise we get a few lines of log output from the previous program before it's killed, especially with #38 making it more common to connect when code is already running.

This makes the API less orthogonal, but the stop command needs to happen at a particular point -- between opening the device and setting the alternate setting -- which happens inside `.claim()`, so we pass a parameter there. Better suggestions accepted.
