### PR TITLE
adds a --help flag to commands that need arguments

### DIFF
--- a/bin/tessel-debug.js
+++ b/bin/tessel-debug.js
@@ -33,6 +33,11 @@ var argv = require("nomnom")
     flag: true,
     help: '[Tessel] Push a single script file to Tessel.'
   })
+  .option('help',{
+    abbr: 'h',
+    flag: true,
+    help: 'Show usage for Tessel debug'
+  })
   .parse();
 
 function usage () {

--- a/bin/tessel-node.js
+++ b/bin/tessel-node.js
@@ -57,7 +57,11 @@ var argv = require("nomnom")
     flag: true,
     help: '[Tessel] Push a single script file to Tessel.'
   })
-
+  .option('help', {
+    abbr: 'h',
+    flag: true,
+    help: 'Show usage for tessel node'
+  })
   .parse();
 
 argv.verbose = !argv.quiet;
@@ -144,8 +148,9 @@ common.controller(true, function (err, client) {
     process.on('SIGINT', function() {
       setTimeout(function () {
         // timeout :|
+        console.log(colors.grey('Script aborted'));
         process.exit(131);
-      }, 5000);
+      }, 200);
       client.stop();
     });
 

--- a/bin/tessel-push.js
+++ b/bin/tessel-push.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 var common = require('../src/cli')
+  , colors = require('colors')
+  ;
 
 // Setup cli.
 common.basic();
@@ -38,6 +40,11 @@ var argv = require("nomnom")
     abbr: 's',
     flag: true,
     help: '[Tessel] Push a single script file to Tessel.'
+  })
+  .option('help', {
+    abbr: 'h',
+    flag: true,
+    help: 'Show usage for tessel push'
   })
   .parse();
 
@@ -91,7 +98,10 @@ common.controller(true, function (err, client) {
     flash: true,
   }, function (err) {
 
+    console.log(colors.green("Finished deployment"));
+
     function exit(code) {
+      console.log(colors.green("Run"), colors.red("tessel listen"), colors.green("or"), colors.red("tessel push <script.js> -l"), colors.green("to see logged output"));
       client.close(function () {
         process.exit(code || 0);
       });

--- a/bin/tessel-version.js
+++ b/bin/tessel-version.js
@@ -5,8 +5,42 @@ var common = require('../src/cli')
 // Setup cli.
 common.basic();
 
-try {
-  console.log(require('../package.json').version.replace(/^v?/, 'v'))
-} catch (e) {
-  console.error('version unknown');
+// Command-line arguments
+var argv = require("nomnom")
+  .script('tessel-version')
+  .option('board', {
+    abbr: 'b',
+    flag: true,
+    help: '[Tessel] Get the version information of the connected Tessel board.',
+  })
+  .option('help', {
+    abbr: 'h',
+    help: 'Show usage for tessel version'
+  })
+  .parse();
+
+function usage () {
+  console.error(require('nomnom').getUsage());
+  process.exit(1);
 }
+
+if (argv.board){
+  common.controller(true, function (err, client) {
+    client.wifiVer(function(err, wifiVer){
+      console.log("Serial #:", client.serialNumber);
+      console.log("Wifi Version:", wifiVer);
+      console.log("Firmware Version:", client.version.firmware_git);
+      console.log("Runtime Version:", client.version.runtime_git);
+      client.close(function () {
+        process.exit(0);
+      });
+    });
+  });
+} else {
+  try {
+    console.log(require('../package.json').version.replace(/^v?/, 'v'))
+  } catch (e) {
+    console.error('version unknown');
+  }
+}
+

--- a/bin/tessel-wifi.js
+++ b/bin/tessel-wifi.js
@@ -1,15 +1,48 @@
 #!/usr/bin/env node
 
 var common = require('../src/cli')
+  , colors = require('colors')
+  , util = require('util')
+  ;
 
 // Setup cli.
 common.basic();
 
-var argv = require('optimist').argv;
+// Command-line arguments
+var argv = require("nomnom")
+  .script('tessel-wifi')
+  .option('list', {
+    abbr: 'l',
+    flag: true,
+    help: '[Tessel] List available wifi networks.',
+  })
+  .option('network', {
+    abbr: 'n',
+    help: '[Tessel] The network to connect to.'
+  })
+  .option('password', {
+    abbr: 'p',
+    help: '[Tessel] Password of the network. Omit for unsecured networks.'
+  })
+  .option('security', {
+    abbr: 's',
+    default: 'wpa2',
+    help: '[Tessel] Security type of the network, one of (wpa2|wpa|wep). Omit for unsecured networks.'
+  })
+  .option('help', {
+    abbr: 'h',
+    help: '[Tessel] Show usage for tessel wifi'
+  })
+  .parse();
+
+function usage () {
+  console.error(require('nomnom').getUsage());
+  process.exit(1);
+}
 
 common.controller(false, function (err, client) {
   client.listen(true, null); // TODO: should use [20, 21, 22, 86] once firmware logs at the right level
-  if (argv._.length == 1) {
+  if (argv.list) {
     client.wifiStatus(function (err, data) {
       Object.keys(data).map(function (key) {
         if (key.toUpperCase() == "IP"){
@@ -22,21 +55,14 @@ common.controller(false, function (err, client) {
     })
 
   } else {
-    // if (argv._.length < 3) {
-    //   usage();
-    //   process.exit(1);
-    // }
+    if (!argv.network){
+      usage();
+    }
 
     function retry () {
-      var ssid = argv._[1];
-      var pass = argv._[2] || "";
-      var security = (argv._[3] || (pass ? 'wpa2' : 'unsecure')).toLowerCase();
-
-      // Only defer to make print after thing.
-      client.once('connect', function () {
-        console.log(('Network ' + JSON.stringify(ssid) + 
-          ' (pass ' + JSON.stringify(pass) + ') with ' + security + ' security'));
-      });
+      var ssid = argv.network;
+      var pass = argv.password || "";
+      var security = (argv.security || (pass ? 'wpa2' : 'unsecure')).toLowerCase();
 
       client.configureWifi(ssid, pass, security, {
         timeout: argv.timeout || 8
@@ -45,6 +71,7 @@ common.controller(false, function (err, client) {
           console.error('Retrying...');
           setImmediate(retry);
         } else {
+          console.log(colors.grey(util.format('Connected to network %s (pw: %s) with %s security', ssid, pass, security)));
           client.close();
         }
       });

--- a/bin/tessel.js
+++ b/bin/tessel.js
@@ -25,19 +25,17 @@ function usage () {
     "   tessel <filename>\n" +
     "   tessel list\n" +
     "   tessel logs\n" +
-    "   tessel push <filename> [-s] [-l]\n" +
-    "          push a script to flash memory on Tessel and run it\n" +
-    "          -s push the specified file only (rather than associated files and modules)\n" + 
-    "          -l stay connected and display logs\n" + 
+    "   tessel push <filename> [options]\n" +
+    "          see 'tessel push --help' for options list\n" +
     "   tessel run <filename> [args...]\n" +
     "          run a script temporarily without writing it to flash\n" +
     "          -s push the specified file only (rather than associated files and modules)\n" + 
     "   tessel repl\n" +
     "          interative JavaScript shell\n" +
-    "   tessel wifi <ssid> <pass> <security (wep/wpa/wpa2, wpa2 by default)>\n"+
-    "   tessel wifi <ssid>\n" +
+    "   tessel wifi -n <ssid> -p <pass> -s <security (wep/wpa/wpa2, wpa2 by default)>\n"+
+    "   tessel wifi -n <ssid>\n" +
     "          connects to a wifi network without a password\n" + 
-    "   tessel wifi\n" +
+    "   tessel wifi -l\n" +
     "          see current wifi status\n" + 
     "   tessel stop\n" +
     "   tessel check <file>\n" + 
@@ -51,6 +49,10 @@ function usage () {
     "   tessel blink\n" +
     "   tessel debug [script]\n" +
     "          runs through debug script and uploads logs\n" +
+    "   tessel version\n" +
+    "          show version\n" +
+    "   tessel version --board\n" +
+    "          show version of the connected Tessel\n" +
     ""
     );
 }


### PR DESCRIPTION
Updated the following:
- adds a --help flag to push, debug, node, version, and wifi commands
- `tessel wifi` now takes arguments for ssid, pw, and security type instead of relying on an order
- `tessel version` can now display version information of a connected Tessel (CC version, Firmware, and Runtime version)
