### PR TITLE
Fail gracefully on messages that don't end

### DIFF
--- a/src/tessel_usb.js
+++ b/src/tessel_usb.js
@@ -201,7 +201,7 @@ Tessel.prototype._receiveMessages = function _receiveMessages() {
 			buffers = [];
 		} else if (buffers.length * transferSize > 32 * 1024 * 1024) {
 			// The message wouldn't fit in Tessel's memory. It probably didn't mean to send this...
-			throw new Error("Malformed message (oversize): " + buffers[0].slice(0, 8))
+			throw new Error("Malformed message (oversize): " + buffers[0].toString('hex', 0, 8))
 		}
 	});
 };


### PR DESCRIPTION
If a message is longer than 32MB, something's gone terribly wrong, and it's probably not going to stop any time soon.
