### PR TITLE
Fixes ranking of firmware versions to match semver.

### DIFF
--- a/bin/tessel-update.js
+++ b/bin/tessel-update.js
@@ -191,8 +191,17 @@ if (argv.list){
     }
 
     function tagsort (a, b) {
-      if (a.url < b.url) return 1;
-      if (a.url > b.url) return -1;
+      if (semver.valid(a) && !semver.valid(b)) {
+        return -1;
+      }
+      if (!semver.valid(a) && semver.valid(b)) {
+        return 1;
+      }
+      if (semver.valid(a) && semver.valid(b)) {
+        return semver.lt(a, b) ? 1 : semver.gt(a, b) ? -1 : 0;
+      }
+      if (a < b) return 1;
+      if (a > b) return -1;
       return 0;
     }
 


### PR DESCRIPTION
This now lists 0.1.11 at top:

```
➜  cli git:(master) ✗ tessel update --list
INFO Switch to any of these builds with `tessel update -b <build name>`
  o current
  o 0.1.11
  o 0.1.10
  o 0.1.9
  o 0.1.8
  o 0.1.7
  o 0.1.6
  o 0.1.5
  o 0.1.4
  o 0.1.3
  ...
```

The old sorting code was checking a property, `.url`, that didn't exist anyway.
