### PR TITLE
[NRY] Changes for node-usb 0.4 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "my-local-ip": "~1.0.0",
     "nomnom": "~1.6.2",
     "read": "^1.0.5",
-    "request": "~2.33.0",
+    "request": "~2.47.0",
     "semver": "^2.3.0",
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",
     "temp": "~0.6.0",
-    "usb": "~0.3.11"
+    "usb": "~0.4.0"
   },
   "devDependencies": {
     "tap": "~0.4.8",

--- a/src/commands.js
+++ b/src/commands.js
@@ -174,8 +174,8 @@ prototype.initCommands = function () {
 prototype.enterBootloader = function (next) {
   var self = this;
   self.claim(true, function() {
-    self.log_ep.stopStream();
-    self.msg_in_ep.stopStream();
+    self.log_ep.stopPoll();
+    self.msg_in_ep.stopPoll();
     commands.enterBootloader(self, function(err) {
       if (err) return next && next(err);
       self.usb.close();

--- a/src/tessel_usb.js
+++ b/src/tessel_usb.js
@@ -32,8 +32,6 @@ if (usb_debug) {
   usb.setDebugLevel(usb_debug);
 }
 
-var isWindows = /^win/.test(process.platform);
-
 // Common base support for bootloader and app mode
 function TesselBase() {}
 util.inherits(TesselBase, EventEmitter);
@@ -60,11 +58,7 @@ TesselBase.prototype.init = function init(next) {
 TesselBase.prototype.reFind = function reFind(desiredMode, next) {
   var self = this;
   var retrycount = 16;
-  
-  if (isWindows) {
-    self.usb.__destroy();
-  }
-  
+
   function retry (error) {
     deviceBySerial(self.serialNumber, function(err, device) {
       // Ignore errors until timeout (another device may fail, but that doesn't
@@ -72,9 +66,6 @@ TesselBase.prototype.reFind = function reFind(desiredMode, next) {
       if (device && device.mode === desiredMode) {
         return next(device.initError, device);
       } else if (--retrycount > 0) {
-        if (device && isWindows) {
-          device.usb.__destroy();
-        }
         return setTimeout(retry, 500);
       } else {
         var msg;
@@ -215,7 +206,7 @@ Tessel.prototype.listen = function listen(deprecated, levels) {
 
 Tessel.prototype._receiveLogs = function _receiveLogs() {
   var self = this;
-  self.log_ep.startStream(4, 4096);
+  self.log_ep.startPoll(4, 4096);
   self.log_ep.on('data', function(data) {
     var pos = 0;
     while (pos < data.length) {
@@ -271,7 +262,7 @@ Tessel.prototype._receiveMessages = function _receiveMessages() {
   var self = this;
 
   var transferSize = 4096;
-  self.msg_in_ep.startStream(2, transferSize);
+  self.msg_in_ep.startPoll(2, transferSize);
 
   var buffers = [];
   self.msg_in_ep.on('data', function(data) {
@@ -388,10 +379,6 @@ function deviceBySerial(serial, next) {
     for (var i=0; i<devices.length; i++) {
       if (!serial || serial === devices[i].serialNumber) {
         return next(devices[i].initError, devices[i])
-      } else {
-        if (isWindows) {
-          devices[i].usb.__destroy();
-        }
       }
     }
     if (err) return next(err);
@@ -406,9 +393,6 @@ exports.listDevices = function listDevices(next) {
         return new TesselBoot(dev);
       } else {
         return new Tessel(dev);
-      }
-      if (isWindows) {
-        dev.__destroy();
       }
     }
   }).filter(function(x) {return x});


### PR DESCRIPTION
[pending node-usb 0.4 release]

* Support for Node 0.11
* Use hotplug-patched libusb on Windows, removing the `__destroy` hack

Tested on

* [x] Ubuntu 14.04 64-bit, Node 0.10.25
* [x] Ubuntu 14.04 32-bit, Node 0.11.14
* [x] Windows 7 32-bit, Node 0.10.30
* [ ] OS X 64-bit, Node 0.10