### PR TITLE
Flags any runtime_version < 1.0.0 as supporting old bytecode.

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -147,6 +147,10 @@ tessel.Tessel.prototype.run = function (pushpath, argv, bundleopts, next)
   }
   var verbose = !bundleopts.quiet;
 
+  if (!this._supportsOldBytecode()) {
+    bundleopts.compileBytecode = false;
+  }
+
   // Bundle code based on file path.
   tessel.bundleScript(pushpath, argv, bundleopts, function (err, tarbundle) {
     verbose && logs.info('Deploying bundle (' + humanize.filesize(tarbundle.length) + ')...');

--- a/src/tessel_usb.js
+++ b/src/tessel_usb.js
@@ -12,6 +12,7 @@ var DFU = 'MOCK_USB' in process.env ? {} : require('../dfu/dfu');
 var util = require('util');
 var async = require('async');
 var EventEmitter = require('events').EventEmitter;
+var semver = require('semver')
 
 var TESSEL_VID = 0x1d50;
 var TESSEL_PID = 0x6097;
@@ -345,6 +346,10 @@ Tessel.prototype.wifiVer = function (next) {
     next(null, version);
   });
 }
+
+Tessel.prototype._supportsOldBytecode = function () {
+  return !('runtime_version' in this.version && semver.satisfies(this.version.runtime_version, '>= 1.0.0'));
+};
 
 exports.findTessel = function findTessel(opts, next) {
   if (opts.stop   === undefined) opts.stop = false;


### PR DESCRIPTION
This would be paired with https://github.com/tessel/firmware/commit/1c47d42e89546127801e30249c744e44b7876111.

Colony with interpreter is given the `runtime_version` semver of v1.0.0. This is added to the version_info struct as a heuristic. This is used to determine if old Tessels support bytecode. Old versions lacking `runtime_version` (read: all) will use the default value of "true".

(No idea how this `runtime_version` will be updated, but probably not hardcoded.)
