### PR TITLE
Updates colony-compiler version and line number embedding.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "~0.2.9",
-    "colony-compiler": "~0.6.21",
+    "colony-compiler": "~0.6.23",
     "colors": "~0.6.0-1",
     "colorsafeconsole": "0.0.4",
     "debug": "^0.8.1",

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -109,7 +109,9 @@ exports.bundleFiles = function (startpath, args, files, opts, next)
 
       try {
         var source = fs.readFileSync(fullpath, 'utf-8');
-        var res = colonyCompiler.colonize(source);
+        var res = colonyCompiler.colonize(source, {
+          embedLineNumbers: !compileBytecode
+        });
       } catch (e) {
         if (!(e instanceof SyntaxError)) {
           throw e;
@@ -125,7 +127,9 @@ exports.bundleFiles = function (startpath, args, files, opts, next)
         ].join('\n');
         // Files with syntax errors can't be compiled.
         // We can pretend they were thrown by our parser though, at runtime.
-        var res = colonyCompiler.colonize('throw new SyntaxError(' + JSON.stringify(message) + ')')
+        var res = colonyCompiler.colonize('throw new SyntaxError(' + JSON.stringify(message) + ')', {
+          embedLineNumbers: !compileBytecode
+        })
       }
 
       if (!compileBytecode) {


### PR DESCRIPTION
Since character offsets are useless without original source anyway, I just interpret no bytecode == want line numbers instead, which works ~for now~.
