### PR TITLE
Update node-usb to 1.0

### DIFF
--- a/.travis.linux.yml
+++ b/.travis.linux.yml
@@ -5,4 +5,4 @@ language: node_js
 node_js:
   - "0.10"
 before_install:
-  - sudo apt-get install pkg-config build-essential libusb-1.0-0-dev
+  - sudo apt-get install pkg-config build-essential libusb-1.0-0-dev libudev-dev

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",
     "temp": "~0.6.0",
-    "usb": "~0.3.11"
+    "usb": "~1.0.4"
   },
   "devDependencies": {
     "tap": "~0.4.8",

--- a/src/commands.js
+++ b/src/commands.js
@@ -180,8 +180,8 @@ prototype.initCommands = function () {
 prototype.enterBootloader = function (next) {
   var self = this;
   self.claim(true, function() {
-    self.log_ep.stopStream();
-    self.msg_in_ep.stopStream();
+    self.log_ep.stopPoll();
+    self.msg_in_ep.stopPoll();
     commands.enterBootloader(self, function(err) {
       if (err) return next && next(err);
       self.usb.close();

--- a/src/commands.js
+++ b/src/commands.js
@@ -180,13 +180,15 @@ prototype.initCommands = function () {
 prototype.enterBootloader = function (next) {
   var self = this;
   self.claim(true, function() {
-    self.log_ep.stopPoll();
-    self.msg_in_ep.stopPoll();
-    commands.enterBootloader(self, function(err) {
-      if (err) return next && next(err);
-      self.usb.close();
-      self.closed = true;
-      self.reFind('boot', next);
+    self.log_ep.stopPoll(function() {
+      self.msg_in_ep.stopPoll(function() {
+        commands.enterBootloader(self, function(err) {
+          if (err) return next && next(err);
+          self.usb.close();
+          self.closed = true;
+          self.reFind('boot', next);
+        });
+      });
     });
   });
 };

--- a/src/tessel_usb.js
+++ b/src/tessel_usb.js
@@ -32,8 +32,6 @@ if (usb_debug) {
   usb.setDebugLevel(usb_debug);
 }
 
-var isWindows = /^win/.test(process.platform);
-
 // Common base support for bootloader and app mode
 function TesselBase() {}
 util.inherits(TesselBase, EventEmitter);
@@ -60,11 +58,7 @@ TesselBase.prototype.init = function init(next) {
 TesselBase.prototype.reFind = function reFind(desiredMode, next) {
   var self = this;
   var retrycount = 16;
-  
-  if (isWindows) {
-    self.usb.__destroy();
-  }
-  
+
   function retry (error) {
     deviceBySerial(self.serialNumber, function(err, device) {
       // Ignore errors until timeout (another device may fail, but that doesn't
@@ -72,9 +66,6 @@ TesselBase.prototype.reFind = function reFind(desiredMode, next) {
       if (device && device.mode === desiredMode) {
         return next(device.initError, device);
       } else if (--retrycount > 0) {
-        if (device && isWindows) {
-          device.usb.__destroy();
-        }
         return setTimeout(retry, 500);
       } else {
         var msg;
@@ -215,7 +206,7 @@ Tessel.prototype.listen = function listen(deprecated, levels) {
 
 Tessel.prototype._receiveLogs = function _receiveLogs() {
   var self = this;
-  self.log_ep.startStream(4, 4096);
+  self.log_ep.startPoll(4, 4096);
   self.log_ep.on('data', function(data) {
     var pos = 0;
     while (pos < data.length) {
@@ -271,7 +262,7 @@ Tessel.prototype._receiveMessages = function _receiveMessages() {
   var self = this;
 
   var transferSize = 4096;
-  self.msg_in_ep.startStream(2, transferSize);
+  self.msg_in_ep.startPoll(2, transferSize);
 
   var buffers = [];
   self.msg_in_ep.on('data', function(data) {
@@ -388,10 +379,6 @@ function deviceBySerial(serial, next) {
     for (var i=0; i<devices.length; i++) {
       if (!serial || serial === devices[i].serialNumber) {
         return next(devices[i].initError, devices[i])
-      } else {
-        if (isWindows) {
-          devices[i].usb.__destroy();
-        }
       }
     }
     if (err) return next(err);
@@ -406,9 +393,6 @@ exports.listDevices = function listDevices(next) {
         return new TesselBoot(dev);
       } else {
         return new Tessel(dev);
-      }
-      if (isWindows) {
-        dev.__destroy();
       }
     }
   }).filter(function(x) {return x});


### PR DESCRIPTION
Except for `tessel repl`, which hangs on Linux and tries to run invalid Lua on Windows. (No regression on 0.10)

Tested on 
* Linux (Ubuntu 14.10) Node 0.10.25
* Linux Node 0.12.0
* Linux io.js 1.0.4
* Windows 7 Node 0.12