### PR TITLE
Replace x86 binaries with MIPS binaries on bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mkdirp": "~0.3.5",
     "my-local-ip": "~1.0.0",
     "nomnom": "~1.6.2",
-    "request": "~2.47.0",
+    "request": "^2.47.0",
     "semver": "^2.3.0",
     "structured-clone": "~0.2.2",
     "tar": "~0.1.18",

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ exports.Tessel = tessel_usb.Tessel;
 exports.findTessel = tessel_usb.findTessel;
 exports.listDevices = tessel_usb.listDevices;
 exports.bundleFiles = bundle.bundleFiles;
+exports.tarCode = bundle.tarCode;
 
 require('./commands');
 require('./script');


### PR DESCRIPTION
Still needs a bit of cleanup, but works correctly when the right binaries are in the S3 bucket.