### PR TITLE
Avoid throwing error and exiting with no message when build server is not responding as expected.

### DIFF
--- a/bin/tessel-update.js
+++ b/bin/tessel-update.js
@@ -205,6 +205,9 @@ if (argv.list){
       return 0;
     }
 
+    if (!allBuilds) {
+      return logs.err("There was an error getting build information.");
+    }
     logs.info("Switch to any of these builds with `tessel update -b <build name>`");
     var alltags = allBuilds.filter(function (file) {
       return file.url.match(/^firmware\/./) && file.url.match(/\.bin$/);


### PR DESCRIPTION
Hey.

As you probably know (I also posted this on IRC yesterday) your build server ssl certificate is expired. 

Among other things, this makes it hard to do `tessel update` without some hacks. When there is no builds returned it would just exit with 

```
TypeError: Cannot call method 'filter' of null
```

Here is a PR that at least shows the user an error, and not exits with a TypeError