### PR TITLE
Added support for fakes

### DIFF
--- a/bin/tessel-fake.js
+++ b/bin/tessel-fake.js
@@ -1,50 +1,10 @@
-// Fake tessel implementation
-
-var colors = require('colors');
-
-(function fakeTessel() {
-    
-    var leds = [
-        { color: "bgGreen", name: "LED1" },
-        { color: "bgBlue", name: "LED2" },
-        { color: "bgRed", name: "Error"},
-        { color: "bgYellow", name: "Conn"}
-    ];
-    
-    function led(index, state) {
-        var selected = leds[index];
-        return colors[(state ? selected.color : "black")].white(selected.name); 
-    }
-    
-    function log(what) {
-        console.info(colors.cyan("T | " + what));   
-    }
-    
-    var pin = function(ledIndex) {
-        
-        var ledState = false;
-        
-        return { 
-            'output': function(value) {
-                ledState = value; 
-                log("Outputted " + value + " on " + led(ledIndex, value));
-                return this; 
-            },
-            'toggle': function() {
-                ledState = !ledState;
-                log("Toggled " + led(ledIndex, ledState));
-            } 
-        }
-    }; 
-    
-    exports.led = [
-           pin(0),
-           pin(1),
-           pin(2),
-           pin(3),
-        ];    
-        
-                
+/* tessel fake
+ * - Execute the passed script as if it was being processed by the hardware.
+ * Requires consumer to also use module tessel-fakes (https://www.npmjs.com/package/tessel-fakes) 
+ * and to require this module, rather than tessel when running fakes
+ * (Alternately: Rename the tessel-fakes folder after npm install...)
+ */
+(function tesselFake() {
     var path = require('path'), 
     common = require('../src/cli'), 
     colors = require('colors'); 

--- a/bin/tessel-fake.js
+++ b/bin/tessel-fake.js
@@ -1,0 +1,55 @@
+// Fake tessel implementation
+
+var colors = require('colors');
+
+(function fakeTessel() {
+    
+    var leds = [
+        { color: "bgGreen", name: "LED1" },
+        { color: "bgBlue", name: "LED2" },
+        { color: "bgRed", name: "Error"},
+        { color: "bgYellow", name: "Conn"}
+    ];
+    
+    function led(index, state) {
+        var selected = leds[index];
+        return colors[(state ? selected.color : "black")].white(selected.name); 
+    }
+    
+    function log(what) {
+        console.info(colors.cyan("T | " + what));   
+    }
+    
+    var pin = function(ledIndex) {
+        
+        var ledState = false;
+        
+        return { 
+            'output': function(value) {
+                ledState = value; 
+                log("Outputted " + value + " on " + led(ledIndex, value));
+                return this; 
+            },
+            'toggle': function() {
+                ledState = !ledState;
+                log("Toggled " + led(ledIndex, ledState));
+            } 
+        }
+    }; 
+    
+    exports.led = [
+           pin(0),
+           pin(1),
+           pin(2),
+           pin(3),
+        ];    
+        
+                
+    var path = require('path'), 
+    common = require('../src/cli'), 
+    colors = require('colors'); 
+
+    common.basic();
+    var script = path.resolve(process.cwd(), process.argv[2]);
+    require(script); 
+})(); 

--- a/bin/tessel.js
+++ b/bin/tessel.js
@@ -71,6 +71,7 @@ var builtinCommands = {
   'install-drivers': 'install-drivers',
   'trademark' : 'trademark',
   'boot': 'boot',
+  'fake': 'fake'
 }
 
 if (process.argv.length < 3 || !builtinCommands[process.argv[2]]) {


### PR DESCRIPTION
Hi! Being inspired by your project and wanting to try out developing for the tessle NOW-NOW-NOW, I've created a fakes extension which I'd love for you to merge.

Syntax: `tessel fake <script name>`

With the [tessel-fakes](https://www.npmjs.com/package/tessel-fakes) npm package, we have support for blinky:

![tessel-fakes](https://cloud.githubusercontent.com/assets/1975185/8394570/38139f1e-1d3e-11e5-95ac-ba4fd23b9e45.png)

I will write a blog post about this support once the merge is complete. :-)

